### PR TITLE
Fixing figshare 403s

### DIFF
--- a/mni.Rproj
+++ b/mni.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: a52a8b52-9142-4f16-a89e-41fdc244895b
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/tests/testthat/test-figshare.R
+++ b/tests/testthat/test-figshare.R
@@ -7,7 +7,7 @@ df = env$mni_figshare
 testthat::test_that("httr::HEAD returns 200 for Figshare", {
 
   results = sapply(df$download_url, function(url) {
-    res = httr::HEAD(url)
+    res = httr::HEAD(strsplit(httr::HEAD(url)$url, split="[?]")[[1]][1])
     testthat::expect_lte(httr::status_code(res), 400)
   })
   testthat::expect_true(all(results == 200))


### PR DESCRIPTION
Tests were failing (403s) for all figshare files. Not sure if this is the best approach to fix this issue but it does the job. 
--
> httr::HEAD('https://ndownloader.figshare.com/files/13659158')
Response [https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/13659158/mni_icbm152_csf_tal_nlin_sym_09c.nii.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIYCQYOYV5JSSROOA/20250217/eu-west-1/s3/aws4_request&X-Amz-Date=20250217T173717Z&X-Amz-Expires=10&X-Amz-SignedHeaders=host&X-Amz-Signature=4b1445f81484f1bec549c409440d4001d21656875f83cd6e8e2e762588925b33]
  Date: 2025-02-17 17:37
  Status: 403
  Content-Type: application/xml
<EMPTY BODY>

--
> httr::HEAD(strsplit(httr::HEAD('https://ndownloader.figshare.com/files/13659158')$url, split="[?]")[[1]][1])
Response [https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/13659158/mni_icbm152_csf_tal_nlin_sym_09c.nii.gz]
  Date: 2025-02-17 17:38
  Status: 200
  Content-Type: application/gzip
<EMPTY BODY>